### PR TITLE
feat: add hybridnorm_v3 with apply_residual_norm option

### DIFF
--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -3039,7 +3039,7 @@ class TransformerFeedForwardLayer(BaseLayer):
             "linear2",
             cfg.linear2.set(input_dim=hidden_dim, output_dim=cfg.input_dim),
         )
-        if cfg.structure in ["prenorm", "hybridnorm", "hybridnorm_v2", "hybridnorm_v3" "nonorm"]:
+        if cfg.structure in ["prenorm", "hybridnorm", "hybridnorm_v2", "hybridnorm_v3", "nonorm"]:
             self._add_child("dropout1", cfg.dropout)
             self._add_child("dropout2", cfg.dropout)
         elif cfg.structure in ["postnorm"]:

--- a/axlearn/common/attention.py
+++ b/axlearn/common/attention.py
@@ -2589,6 +2589,8 @@ class TransformerAttentionLayer(BaseLayer):
         # Optional apply_residual_norm parameter.
         apply_residual_norm: Optional[bool] = None
 
+        residual_weight: float = 1.0
+
     def __init__(self, config: Config, *, parent: Module):
         super().__init__(config, parent=parent)
         cfg = self.config
@@ -2763,6 +2765,8 @@ class TransformerAttentionLayer(BaseLayer):
             atten_state, atten_output = attention_thunk(fn_input)
             # the output of the transformation function.
             fn_output = self.stochastic_depth(self.dropout(self.prenorm(atten_output.data)))
+            if cfg.residual_weight != 1:
+                fn_output *= cfg.residual_weight
             # the final output with res_value & fn_output.
             data = res_value + fn_output
         else:
@@ -3121,6 +3125,8 @@ class TransformerFeedForwardLayer(BaseLayer):
             # the output of the transformation function.
             fn_output = self.stochastic_depth(self.dropout2(self.prenorm(ffn_output)))
             # the final output with res_value & fn_output.
+            if cfg.residual_weight != 1:
+                fn_output *= cfg.residual_weight
             x = res_value + fn_output
         elif cfg.structure == "nonorm":
             x = inputs

--- a/axlearn/common/mixture_of_experts.py
+++ b/axlearn/common/mixture_of_experts.py
@@ -850,6 +850,8 @@ class TransformerFeedForwardMoE(BaseLayer):
             ffn_output = self._dispatch_and_combine(fn_input)
             # the output of the transformation function.
             fn_output = self.stochastic_depth(self.dropout2(self.prenorm(ffn_output)))
+            if cfg.residual_weight != 1:
+                fn_output *= cfg.residual_weight
             # the final output with res_value & fn_output.
             x = res_value + fn_output
         elif cfg.structure == "nonorm":


### PR DESCRIPTION
Add structure `hybridnorm_v3` described in [Decouple the layer normalization between the input and residual components](https://quip-apple.com/HqeZAMaG6QJL#temp:C:XAA43da0aa7fb14443daf3cbc886) with apply_residual_norm option.